### PR TITLE
Add support for more encoding options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.idea

--- a/src/LitEmoji.php
+++ b/src/LitEmoji.php
@@ -4,169 +4,7 @@ namespace LitEmoji;
 
 class LitEmoji
 {
-    /**
-     * Converts all unicode emoji and HTML entities to plaintext shortcodes.
-     *
-     * @param string $content
-     * @return string
-     */
-    public static function encodeShortcode($content)
-    {
-        $mb_regex = '/(
-    		     \x23\xE2\x83\xA3               # Digits
-    		     [\x30-\x39]\xE2\x83\xA3
-    		   | \xF0\x9F[\x85-\x88][\xA6-\xBF] # Enclosed characters
-    		   | \xF0\x9F[\x8C-\x97][\x80-\xBF] # Misc
-    		   | \xF0\x9F\x98[\x80-\xBF]        # Smilies
-    		   | \xF0\x9F\x99[\x80-\x8F]
-    		   | \xF0\x9F\x9A[\x80-\xBF]        # Transport and map symbols
-    		)/x';
-
-        $replacement = '';
-        $encoding = mb_detect_encoding($content);
-        $codepoints = array_flip(self::$shortcodes);
-
-        /* Break content along codepoint boundaries */
-        $parts = preg_split(
-            $mb_regex,
-            $content,
-            -1,
-            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
-        );
-
-        /* Reconstruct content using shortcodes */
-        $sequence = [];
-        foreach ($parts as $offset => $part) {
-            if (preg_match($mb_regex, $part)) {
-                $part = mb_convert_encoding($part, 'UTF-32', $encoding);
-                $words = unpack('N*', $part);
-                $codepoint = sprintf('%X', reset($words));
-
-                $sequence[] = $codepoint;
-
-                if (isset($codepoints[$codepoint])) {
-                    $replacement .= ":$codepoints[$codepoint]:";
-                    $sequence = [];
-                } else {
-                    /* Check multi-codepoint sequence */
-                    $multi = implode('-', $sequence);
-
-                    if (isset($codepoints[$multi])) {
-                        $replacement .= ":$codepoints[$multi]:";
-                        $sequence = [];
-                    }
-                }
-            } else {
-                $replacement .= $part;
-            }
-        }
-
-        /* Detect HTML entities */
-        $replacements = array();
-        foreach ($codepoints as $codepoint => $shortcode) {
-            $parts = explode('-', $codepoint);
-            $hex = '';
-            $dec = '';
-
-            foreach ($parts as $part) {
-                $hex .= '&#x' . $part . ';';
-                $dec .= '&#' . hexdec($part) . ';';
-            }
-
-            $replacements[$hex] = ':' . $shortcode . ':';
-            $replacements[$dec] = ':' . $shortcode . ':';
-        }
-
-        $replacement = str_replace(array_keys($replacements), $replacements, $replacement);
-
-        return $replacement;
-    }
-
-    /**
-     * Converts all plaintext shortcodes and unicode emoji to HTML entities.
-     *
-     * @param string $content
-     * @return string
-     */
-    public static function encodeHtml($content)
-    {
-        $content = preg_replace_callback('/:([\w\-\+]+):/', function($matches) {
-            if (!isset(self::$shortcodes[$matches[1]])) {
-                return $matches[0];
-            }
-
-            $entity = '';
-            $codepoints = explode('-', self::$shortcodes[$matches[1]]);
-
-            /* Multiple codepoints must be encoded as multiple entities */
-            foreach ($codepoints as $codepoint) {
-                $entity .= "&#x$codepoint;";
-            }
-
-            return $entity;
-        }, $content);
-
-        /* Detect unicode */
-        $mb_regex = '/(
-    		     \x23\xE2\x83\xA3               # Digits
-    		     [\x30-\x39]\xE2\x83\xA3
-    		   | \xF0\x9F[\x85-\x88][\xA6-\xBF] # Enclosed characters
-    		   | \xF0\x9F[\x8C-\x97][\x80-\xBF] # Misc
-    		   | \xF0\x9F\x98[\x80-\xBF]        # Smilies
-    		   | \xF0\x9F\x99[\x80-\x8F]
-    		   | \xF0\x9F\x9A[\x80-\xBF]        # Transport and map symbols
-    		)/x';
-        $encoding = mb_detect_encoding($content);
-        if (preg_match_all($mb_regex, $content, $matches)) {
-            if (!empty($matches[1])) {
-                foreach ($matches[1] as $part) {
-                    $words = unpack('H*', mb_convert_encoding($part, 'UTF-32', $encoding));
-                    if (isset($words[1])) {
-                        $entity = '&#x' . ltrim($words[1], '0') . ';';
-                        $content = str_replace($part, $entity, $content);
-                    }
-                }
-            }
-        }
-
-        return $content;
-    }
-
-    /**
-     * Converts all plaintext shortcodes and HTML entities to unicode codepoints.
-     *
-     * @param string $content
-     * @return string
-     */
-    public static function encodeUnicode($content)
-    {
-        $content = preg_replace_callback('/:([\w\-\+]+):/', function($matches) {
-            if (!isset(self::$shortcodes[$matches[1]])) {
-                return $matches[0];
-            }
-
-            $replacement = '';
-            $codepoints = explode('-', self::$shortcodes[$matches[1]]);
-
-            foreach ($codepoints as $codepoint) {
-                $ulong = hexdec($codepoint);
-                $word = pack('N', $ulong);
-
-                $replacement .= mb_convert_encoding($word, 'UTF-8', 'UTF-32');
-            }
-
-            return $replacement;
-        }, $content);
-
-        $content = html_entity_decode($content);
-
-        return $content;
-    }
-
-    /**
-     * @var array
-     */
-    private static $shortcodes = [
+    const SHORTCODES = [
         '-1' => '1F44E',
         '+1' => '1F44D',
         '100' => '1F4AF',
@@ -1512,4 +1350,213 @@ class LitEmoji
         'zipper_mouth_face' => '1F910',
         'zzz' => '1F4A4'
     ];
+    const MB_REGEX = '/(
+    		     \x23\xE2\x83\xA3               # Digits
+    		     [\x30-\x39]\xE2\x83\xA3
+    		   | \xF0\x9F[\x85-\x88][\xA6-\xBF] # Enclosed characters
+    		   | \xF0\x9F[\x8C-\x97][\x80-\xBF] # Misc
+    		   | \xF0\x9F\x98[\x80-\xBF]        # Smilies
+    		   | \xF0\x9F\x99[\x80-\x8F]
+    		   | \xF0\x9F\x9A[\x80-\xBF]        # Transport and map symbols
+    		)/x';
+
+    private static $shortcodeCodepoints = [];
+    private static $shortcodeEntities = [];
+    private static $entityCodepoints = [];
+
+    /**
+     * Converts all unicode emoji and HTML entities to plaintext shortcodes.
+     *
+     * @param string $content
+     * @return string
+     */
+    public static function encodeShortcode($content)
+    {
+        $content = self::entitiesToUnicode($content);
+        $content = self::unicodeToShortcode($content);
+
+        return $content;
+    }
+
+    /**
+     * Converts all plaintext shortcodes and unicode emoji to HTML entities.
+     *
+     * @param string $content
+     * @return string
+     */
+    public static function encodeHtml($content)
+    {
+        $content = self::unicodeToShortcode($content);
+        $content = self::shortcodeToEntities($content);
+
+        return $content;
+    }
+
+    /**
+     * Converts all plaintext shortcodes and HTML entities to unicode codepoints.
+     *
+     * @param string $content
+     * @return string
+     */
+    public static function encodeUnicode($content)
+    {
+        $content = self::shortcodeToUnicode($content);
+        $content = self::entitiesToUnicode($content);
+
+        return $content;
+    }
+
+    /**
+     * Converts plaintext shortcodes to HTML entities.
+     *
+     * @param string $content
+     * @return string
+     */
+    public static function shortcodeToUnicode($content)
+    {
+        $replacements = self::getShortcodeCodepoints();
+        return str_replace(array_keys($replacements), $replacements, $content);
+    }
+
+    /**
+     * Converts HTML entities to unicode codepoints.
+     *
+     * @param string $content
+     * @return string
+     */
+    public static function entitiesToUnicode($content)
+    {
+        /* Convert HTML entities to uppercase hexadecimal */
+        $content = preg_replace_callback('/\&\#(x?[a-zA-Z0-9]*?)\;/', function($matches) {
+            $code = $matches[1];
+
+            if ($code[0] == 'x') {
+                return '&#x' . strtoupper(substr($code, 1)) . ';';
+            }
+
+            return '&#x' . strtoupper(dechex($code)) . ';';
+        }, $content);
+
+        $replacements = self::getEntityCodepoints();
+        return str_replace(array_keys($replacements), $replacements, $content);
+    }
+
+    /**
+     * Converts unicode codepoints to plaintext shortcodes.
+     *
+     * @param string $content
+     * @return string
+     */
+    public static function unicodeToShortcode($content)
+    {
+        $replacement = '';
+        $encoding = mb_detect_encoding($content);
+        $codepoints = array_flip(self::SHORTCODES);
+
+        /* Break content along codepoint boundaries */
+        $parts = preg_split(
+            self::MB_REGEX,
+            $content,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+        );
+
+        /* Reconstruct content using shortcodes */
+        $sequence = [];
+        foreach ($parts as $offset => $part) {
+            if (preg_match(self::MB_REGEX, $part)) {
+                $part = mb_convert_encoding($part, 'UTF-32', $encoding);
+                $words = unpack('N*', $part);
+                $codepoint = sprintf('%X', reset($words));
+
+                $sequence[] = $codepoint;
+
+                if (isset($codepoints[$codepoint])) {
+                    $replacement .= ":$codepoints[$codepoint]:";
+                    $sequence = [];
+                } else {
+                    /* Check multi-codepoint sequence */
+                    $multi = implode('-', $sequence);
+
+                    if (isset($codepoints[$multi])) {
+                        $replacement .= ":$codepoints[$multi]:";
+                        $sequence = [];
+                    }
+                }
+            } else {
+                $replacement .= $part;
+            }
+        }
+
+        return $replacement;
+    }
+
+    /**
+     * @param string $content
+     * @return string
+     */
+    public static function shortcodeToEntities($content) {
+        $replacements = self::getShortcodeEntities();
+        return str_replace(array_keys($replacements), $replacements, $content);
+    }
+
+    private static function getShortcodeCodepoints()
+    {
+        if (!empty(self::$shortcodeCodepoints)) {
+            return self::$shortcodeCodepoints;
+        }
+
+        foreach (self::SHORTCODES as $shortcode => $codepoint) {
+            $parts = explode('-', $codepoint);
+            $codepoint = '';
+
+            foreach ($parts as $part) {
+                $codepoint .= mb_convert_encoding(pack('N', hexdec($part)), 'UTF-8', 'UTF-32');
+            }
+
+            self::$shortcodeCodepoints[':' . $shortcode . ':'] = $codepoint;
+        }
+
+        return self::$shortcodeCodepoints;
+    }
+
+    private static function getEntityCodepoints()
+    {
+        if (!empty(self::$entityCodepoints)) {
+            return self::$entityCodepoints;
+        }
+
+        foreach (self::SHORTCODES as $shortcode => $codepoint) {
+            $parts = explode('-', $codepoint);
+            $entity = '';
+            $codepoint = '';
+
+            foreach ($parts as $part) {
+                $entity .= '&#x' . $part . ';';
+                $codepoint .= mb_convert_encoding(pack('N', hexdec($part)), 'UTF-8', 'UTF-32');
+            }
+
+            self::$entityCodepoints[$entity] = $codepoint;
+        }
+
+        return self::$entityCodepoints;
+    }
+
+    private static function getShortcodeEntities()
+    {
+        if (!empty(self::$shortcodeEntities)) {
+            return self::$shortcodeEntities;
+        }
+
+        foreach (self::SHORTCODES as $shortcode => $codepoint) {
+            $parts = explode('-', $codepoint);
+            self::$shortcodeEntities[':' . $shortcode . ':'] = '';
+
+            foreach ($parts as $part) {
+                self::$shortcodeEntities[':' . $shortcode . ':'] .= '&#x' . $part .';';
+            }
+        }
+
+        return self::$shortcodeEntities;
+    }
 }

--- a/tests/LitEmojiTest.php
+++ b/tests/LitEmojiTest.php
@@ -25,7 +25,7 @@ class LitEmojiTest extends \PHPUnit_Framework_TestCase
     public function testUnicodeToHtml()
     {
         $text = LitEmoji::encodeHtml('My mixtape is 🔥. Made in 🇦🇺!');
-        $this->assertEquals('My mixtape is &#x1f525;. Made in &#x1f1e6;&#x1f1fa;!', $text);
+        $this->assertEquals('My mixtape is &#x1F525;. Made in &#x1F1E6;&#x1F1FA;!', $text);
     }
 
     public function testShortcodeToUnicode()

--- a/tests/LitEmojiTest.php
+++ b/tests/LitEmojiTest.php
@@ -22,9 +22,21 @@ class LitEmojiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('My mixtape is &#x1F525;. Made in &#x1F1E6;&#x1F1FA;!', $text);
     }
 
+    public function testUnicodeToHtml()
+    {
+        $text = LitEmoji::encodeHtml('My mixtape is 🔥. Made in 🇦🇺!');
+        $this->assertEquals('My mixtape is &#x1f525;. Made in &#x1f1e6;&#x1f1fa;!', $text);
+    }
+
     public function testShortcodeToUnicode()
     {
         $text = LitEmoji::encodeUnicode('My mixtape is :fire:. Made in :flag-au:!');
+        $this->assertEquals('My mixtape is 🔥. Made in 🇦🇺!', $text);
+    }
+
+    public function testHtmlToUnicode()
+    {
+        $text = LitEmoji::encodeUnicode('My mixtape is &#x1f525;. Made in &#x1f1e6;&#x1f1fa;!');
         $this->assertEquals('My mixtape is 🔥. Made in 🇦🇺!', $text);
     }
 


### PR DESCRIPTION
This PR enhances two of the encode methods to support different types of input data. That way we do not need to concern ourselves with what the input data is going to contain and will ensure consistent results.

- `encodeHtml` method now encodes unicode emoji to HTML entities
- `encodeUnicode` method now coverts HTML entities into unicode codepoints

I am not 100% happy with `encodeHtml` so perhaps you have a better solution. I am also not sure of `html_entity_decode` is the best move inside `encodeUnicode` so happy to hear your thoughts.