### PR TITLE
Remove usage of ARRAY_FILTER_USE_KEY

### DIFF
--- a/src/LitEmoji.php
+++ b/src/LitEmoji.php
@@ -194,10 +194,14 @@ class LitEmoji
             return self::$shortcodes;
         }
 
+        $data = require(__DIR__ . '/shortcodes-array.php');
+
         // Skip excluded shortcodes
-        self::$shortcodes = array_filter(require(__DIR__ . '/shortcodes-array.php'), function($code) {
-            return !in_array($code, self::$excludedShortcodes);
-        }, ARRAY_FILTER_USE_KEY);
+        foreach ($data as $code => $codepoint) {
+            if (!in_array($code, self::$excludedShortcodes)) {
+                self::$shortcodes[$code] = $codepoint;
+            }
+        }
 
         return self::$shortcodes;
     }


### PR DESCRIPTION
This PR replaces a call to array_filter with a standard foreach loop in order to maintain compatibility with PHP 5.4, per #7.