### PR TITLE
Upgrade emojibase to use latest version

### DIFF
--- a/bin/generate-shortcodes-array.php
+++ b/bin/generate-shortcodes-array.php
@@ -4,7 +4,7 @@ function normalizeShortcode($shortcode) {
     return str_replace('-', '_', strtolower($shortcode));
 }
 
-$data = json_decode(file_get_contents(__DIR__ . '/../vendor/milesj/emojibase/packages/data/en/compact.json'), true);
+$data = json_decode(file_get_contents(__DIR__ . '/../vendor/milesj/emojibase/packages/data/en/raw.json'), true);
 $emoji_array = require(__DIR__ . '/../src/shortcodes-array.php');
 $existing_shortcodes = array_map('normalizeShortcode', array_keys($emoji_array));
 

--- a/composer.json
+++ b/composer.json
@@ -9,18 +9,18 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",
-        "milesj/emojibase": "2.0.0"
+        "milesj/emojibase": "^3.1.0"
     },
     "repositories": [
         {
             "type": "package",
             "package": {
                 "name": "milesj/emojibase",
-                "version": "2.0.0",
+                "version": "3.1.0",
                 "source": {
                     "url": "https://github.com/milesj/emojibase",
                     "type": "git",
-                    "reference": "tags/emojibase@2.0.0"
+                    "reference": "tags/emojibase-data@3.1.0"
                 }
             }
         }


### PR DESCRIPTION
This PR upgrades [emojibase](https://github.com/milesj/emojibase) to version 3.1.0. The location of the JSON data has changed so I have made changes and run `composer update-resources` to verify it's working. All previous emoji exist.