### PR TITLE
Drop PHP 5.4 and 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
-
-dist: precise
 
 before_script:
   - curl -sSfL -o ~/.phpenv/versions/hhvm/bin/phpunit https://phar.phpunit.de/phpunit-5.7.26.phar

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["php-emoji", "emoji"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/src/LitEmoji.php
+++ b/src/LitEmoji.php
@@ -194,14 +194,10 @@ class LitEmoji
             return self::$shortcodes;
         }
 
-        $data = require(__DIR__ . '/shortcodes-array.php');
-
         // Skip excluded shortcodes
-        foreach ($data as $code => $codepoint) {
-            if (!in_array($code, self::$excludedShortcodes)) {
-                self::$shortcodes[$code] = $codepoint;
-            }
-        }
+        self::$shortcodes = array_filter(require(__DIR__ . '/shortcodes-array.php'), function($code) {
+            return !in_array($code, self::$excludedShortcodes);
+        }, ARRAY_FILTER_USE_KEY);
 
         return self::$shortcodes;
     }


### PR DESCRIPTION
This PR drops support for PHP 5.4 and 5.5. Minimum version is now PHP 5.6.

It also reverts a commit (7de706942359833e1eebc33c1431aef777b535b5) that was made to make LitEmoji work in PHP versions <5.6. Since 5.6 is now our minimum version, this commit can be reverted.