### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        php-versions: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
+        php-versions: [ '7.0', '7.1', '7.2', '7.3', '7.4' ]
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A PHP library simplifying the conversion of unicode, HTML and shortcode emoji.
 
-[![Build Status](https://travis-ci.org/elvanto/litemoji.svg?branch=master)](https://travis-ci.org/elvanto/litemoji)
+![Run Tests](https://github.com/elvanto/litemoji/workflows/Run%20Tests/badge.svg)
 
 ## Installation
 

--- a/tests/LitEmojiTest.php
+++ b/tests/LitEmojiTest.php
@@ -2,7 +2,9 @@
 
 namespace LitEmoji;
 
-class LitEmojiTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class LitEmojiTest extends TestCase
 {
     public function testUnicodeToShortcode()
     {


### PR DESCRIPTION
This PR removes PHP 8.0 from tests as it's failing due to older PHP support. Github Actions caching covered this up!

It also adds the Github Actions statue badge to the README and fixes tests to work wit PHPUnit 6.