### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        php-versions: [ '7.0', '7.1', '7.2', '7.3', '7.4' ]
+        php-versions: [ '7.3', '7.4', '8.0' ]
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "keywords": ["php-emoji", "emoji"],
     "license": "MIT",
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "9.4.*",
         "milesj/emojibase": "6.0.*"
     },
     "repositories": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="vendor/autoload.php">
-    <testsuite>
-        <directory suffix="Test.php">tests</directory>
-    </testsuite>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.4/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         executionOrder="depends,defects"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
This PR adds support for PHP 8.0. In doing so support for PHP 7.2 and below has now been dropped.