### PR TITLE
[HOTFIX] - Expand regex for transport and map symbols

### DIFF
--- a/src/LitEmoji.php
+++ b/src/LitEmoji.php
@@ -12,7 +12,7 @@ class LitEmoji
     		   | \xF0\x9F[\x8C-\x97][\x80-\xBF] # Misc
     		   | \xF0\x9F\x98[\x80-\xBF]        # Smilies
     		   | \xF0\x9F\x99[\x80-\x8F]
-    		   | \xF0\x9F\x9A[\x80-\xBF]        # Transport and map symbols
+    		   | \xF0\x9F[\x9A-\x9B][\x80-\xBF] # Transport and map symbols
     		   | \xF0\x9F[\xA4-\xA7][\x80-\xBF] # Supplementary symbols and pictographs
     		)/x';
 

--- a/tests/LitEmojiTest.php
+++ b/tests/LitEmojiTest.php
@@ -53,4 +53,10 @@ class LitEmojiTest extends TestCase
         LitEmoji::config('excludeShortcodes', ['mobile', 'android', 'mobile_phone']);
         $this->assertEquals(':iphone:', LitEmoji::encodeShortcode('📱'));
     }
+
+    public function testIssue25()
+    {
+        $text = LitEmoji::encodeShortcode('🚀🛒');
+        $this->assertEquals(':rocket::shopping_trolley:', $text);
+    }
 }


### PR DESCRIPTION
This PR expands the multibyte regex for transport and map symbols in response to #25.