### PR TITLE
Add PHP 8.3 and 8.4 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-${{ matrix.php-versions }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        php-versions: [ '7.4', '8.0', '8.1', '8.2' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/src/LitEmoji.php
+++ b/src/LitEmoji.php
@@ -59,7 +59,7 @@ class LitEmoji
      * @param string|null $encoding
      * @return string
      */
-    public static function encodeUnicode(string $content, string $encoding = null): string
+    public static function encodeUnicode(string $content, ?string $encoding = null): string
     {
         $content = self::shortcodeToUnicode($content, $encoding);
         return self::entitiesToUnicode($content, $encoding);
@@ -72,7 +72,7 @@ class LitEmoji
      * @param string|null $encoding
      * @return string
      */
-    public static function shortcodeToUnicode(string $content, string $encoding = null): string
+    public static function shortcodeToUnicode(string $content, ?string $encoding = null): string
     {
         $replacements = self::getShortcodeCodepoints();
 
@@ -100,7 +100,7 @@ class LitEmoji
      * @param string|null $encoding
      * @return string
      */
-    public static function entitiesToUnicode(string $content, string $encoding = null): string
+    public static function entitiesToUnicode(string $content, ?string $encoding = null): string
     {
         $replacements = self::getEntityCodepoints();
 
@@ -139,7 +139,7 @@ class LitEmoji
      * @param string|null $encoding
      * @return string
      */
-    public static function unicodeToShortcode(string $content, string $encoding = null): string
+    public static function unicodeToShortcode(string $content, ?string $encoding = null): string
     {
         $codepoints = self::getShortcodeCodepoints();
 


### PR DESCRIPTION
This PR adds support for PHP 8.3 and 8.4 whilst maintaining backwards compatibility.

It also upgrades `actions/cache` in the GitHub Actions file to `v4`.